### PR TITLE
fix. Заменил метод "haveRated" на "value"

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ use agoalofalife\Orchid\Fields\Rate;
 Rate::make('rate')
     ->count(4)
     ->readonly(true)
-    ->haveRated(5);
+    ->value(5);
 ```
 
 

--- a/resources/views/fields/rate.blade.php
+++ b/resources/views/fields/rate.blade.php
@@ -1,6 +1,6 @@
 @component($typeForm, get_defined_vars())
     <div data-controller="rate" data-rate-count="{{$count}}" data-rate-step="{{$step}}" data-rate-readonly="{{$readonly}}">
-        <div data-rate-value="{{$attributes['haveRated']}}">
+        <div data-rate-value="{{$attributes['value']}}">
             <input type="hidden" {{$attributes}}>
         </div>
     </div>

--- a/src/Fields/Rate.php
+++ b/src/Fields/Rate.php
@@ -32,6 +32,6 @@ class Rate extends Field
     protected $inlineAttributes = [
       'title',
       'name',
-      'haveRated'
+      'value'
     ];
 }


### PR DESCRIPTION
При редактировании записей, у которых уже проставлен рейтинг, не закрашиваются звёзды. Если поменять на более стандартное "value", то всё работает как надо.