### PR TITLE
Makes the Range field work with Orchid listeners

### DIFF
--- a/resources/js/controllers/range_controller.js
+++ b/resources/js/controllers/range_controller.js
@@ -1,7 +1,13 @@
 export default class extends window.Controller {
     connect() {
         let value = this.data.get('value');
-        $(this.element.querySelector(".js-range-slider")).ionRangeSlider();
+        
+        $(this.element.querySelector(".js-range-slider")).ionRangeSlider({
+            onFinish: function (data) {
+                data.input[0].dispatchEvent(new Event('change'));
+            },
+        });
+        
         let range = $(".js-range-slider").data("ionRangeSlider");
 
         if (value !== null) {

--- a/resources/js/controllers/range_controller.js
+++ b/resources/js/controllers/range_controller.js
@@ -1,14 +1,16 @@
 export default class extends window.Controller {
     connect() {
         let value = this.data.get('value');
-        
-        $(this.element.querySelector(".js-range-slider")).ionRangeSlider({
+
+        let input = this.element.querySelector(".js-range-slider");
+
+        $(input).ionRangeSlider({
             onFinish: function (data) {
-                data.input[0].dispatchEvent(new Event('change'));
+                input.dispatchEvent(new Event('change'));
             },
         });
-        
-        let range = $(".js-range-slider").data("ionRangeSlider");
+
+        let range = $(input).data("ionRangeSlider");
 
         if (value !== null) {
             let [from, to] = value.split(';');

--- a/resources/views/fields/range.blade.php
+++ b/resources/views/fields/range.blade.php
@@ -1,12 +1,13 @@
 @component($typeForm, get_defined_vars())
     <div data-controller="range" data-range-value="{{$value}}">
         <input type="text" class="js-range-slider"  {{$attributes}}
-        data-type="double"
+               data-type="{{$type}}"
                data-min="{{$min}}"
                data-max="{{$max}}"
                data-from="{{$from}}"
                data-to="{{$to}}"
                data-grid="{{$hasGrid}}"
+               data-skin="{{$skin}}"
         />
     </div>
 @endcomponent

--- a/src/Fields/Range.php
+++ b/src/Fields/Range.php
@@ -23,7 +23,9 @@ class Range extends Field
         'max' => 1000,
         'from' => 0,
         'to' => 1000,
-        'hasGrid' => false
+        'hasGrid' => false,
+        'type' => 'double',
+        'skin' => 'flat',
     ];
 
     /**


### PR DESCRIPTION
The range field doesn't work with Orchid listeners as change event is not caught by Orchid listener.

This fixes the problem as well as adds two more params to the field - skin and type (double/single)

![image](https://user-images.githubusercontent.com/422942/154848947-141ec68a-31db-4469-90ac-11ae1f76870d.png)
